### PR TITLE
Allow API key to be overridden in web.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Currently this package consists of the Google .NET C# Library for YouTube API's 
 Current AppVeyor build status:
 [![Build status](https://ci.appveyor.com/api/projects/status/ca1w4tu3uib3oltd)](https://ci.appveyor.com/project/warrenbuckley/youtube-umbraco)
 
+###Using your own YouTube API key
+1. Follow the instructions at https://developers.google.com/youtube/v3/getting-started
+2. Add the following `appSetting` key to your `web.config` file:
+
+```
+<appSettings>
+  <add key="YouTube-Video:ApiKey" value="<APIKEY>" />
+</appSettings>
+```
+
 ### Settings (Prevalues)
 The YouTube Channel picker has two settings or prevalues as it's more commonly known:
 

--- a/YouTube/YouTubeHelper.cs
+++ b/YouTube/YouTubeHelper.cs
@@ -1,4 +1,5 @@
-﻿using Google.Apis.Services;
+﻿using System.Web.Configuration;
+using Google.Apis.Services;
 using Google.Apis.YouTube.v3;
 using Google.Apis.YouTube.v3.Data;
 
@@ -19,11 +20,9 @@ namespace YouTube
         /// <returns></returns>
         public static YouTubeService GetYouTubeService()
         {
-
-
             var youTubeService = new YouTubeService(new BaseClientService.Initializer()
-            {
-                ApiKey          = _ApiKey,
+            { 
+                ApiKey          = WebConfigurationManager.AppSettings["YouTube-Umbraco:ApiKey"] ?? _ApiKey,
                 ApplicationName = _ApplicationName
             });
 


### PR DESCRIPTION
Allows configurable API key in the web.config.

Add the following to your web.config file:

```
<appSettings>
  <add key="YouTube-Video:ApiKey" value="<APIKEY>" />
</appSettings>